### PR TITLE
Fix to export manually created stacks

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -118,8 +118,8 @@ func exportTool(ctx *cli.Context) error {
 			}
 		}
 
-		// Continue if project orchestrator is nor cattle or docker-compose is empty
-		if projectMap[item.AccountId] == "-" || item.DockerCompose == "" {
+		// Continue if project orchestrator is nor cattle
+		if projectMap[item.AccountId] == "-" {
 			continue
 		}
 


### PR DESCRIPTION
migration-tools issue that doesn't export manually created stacks. This PR fix it.